### PR TITLE
Packnga is ready for ruby 1.9

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,13 +78,3 @@ Packnga::ReleaseTask.new(spec) do |task|
   task.index_html_dir = "../rroonga/doc/html"
   task.changes = File.read("doc/text/news.textile").split(/^h2\.\s(.*)$/)[2]
 end
-
-namespace :requirement do
-  task :ruby18 do
-    if RUBY_VERSION.to_f >= 1.9
-      raise "This task must be run with ruby1.8."
-    end
-  end
-end
-
-task "build" => "requirement:ruby18"


### PR DESCRIPTION
1.9 系でも build タスクを実行できるようにしました。
### 対応内容

build タスクが requirement:ruby18 に依存していましたが、Ruby1.9 で問題なくビルドできる状態でした。
そこから、Packnga 自体は Ruby 1.9 ready だと考えましたので、requirement:ruby18 に依存しないように Rakefile を修正しました。
