### PR TITLE
ubygems.rb is unavailable on Ruby 2.5

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,8 +19,6 @@
 require "English"
 
 require "pathname"
-require "rubygems"
-require "rubygems/package_task"
 require "bundler/gem_helper"
 
 base_dir = File.join(File.dirname(__FILE__))
@@ -51,7 +49,7 @@ end
 
 desc "Run tests."
 task :test do
-  ruby("-rubygems", "test/run-test.rb")
+  ruby("test/run-test.rb")
 end
 
 task :default => :test


### PR DESCRIPTION
This option only needs Ruby 1.8. and It removed at Ruby 2.5.