### PR TITLE
Fix warning: method redefined; discarding old text_files

### DIFF
--- a/lib/packnga/yard-task.rb
+++ b/lib/packnga/yard-task.rb
@@ -57,11 +57,6 @@ module Packnga
     end
 
     # @private
-    def text_files
-      @text_files ||= []
-    end
-
-    # @private
     def define
       set_default_values
       define_tasks


### PR DESCRIPTION
Since initial values are set in Packnga::DocumentTask as below link, the text_files method is unnecessary.

https://github.com/ranguba/packnga/blob/8e816f53c8d14fe11071b0e3e5fb2e48d6a6b26b/lib/packnga/document-task.rb#L164